### PR TITLE
Add HTML guide pages with embedded videos and Papyrus font

### DIFF
--- a/clinXpert/Abdominal.html
+++ b/clinXpert/Abdominal.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Abdominal - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#128137; Examen Abdominal</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/xmw01rl-SmA"
+                    title="Examen Abdominal"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Se laver les mains.</li>
+            <li>Se pr&eacute;senter : nom et r&ocirc;le.</li>
+            <li>Confirmer l&rsquo;identit&eacute; du patient (nom, date de naissance).</li>
+            <li>Expliquer l&rsquo;examen avec des termes simples et rassurants.</li>
+            <li>Obtenir le consentement pour continuer.</li>
+            <li>Demander si le patient ressent une douleur avant de commencer.</li>
+            <li>Patient en d&eacute;cubitus dorsal, placez-vous &agrave; droite du patient.</li>
+        </ul>
+
+        <h2>2. Inspection</h2>
+        <ul>
+            <li>Rechercher des signes cliniques visibles :
+                <ul>
+                    <li>Respiration abdominale.</li>
+                    <li>Cicatrices chirurgicales.</li>
+                    <li>Distension abdominale ou voussure.</li>
+                    <li>Hernie ou &eacute;ventration.</li>
+                    <li>Points de feu ou l&eacute;sions cutan&eacute;es.</li>
+                    <li>Circulation veineuse collat&eacute;rale.</li>
+                    <li>Pr&eacute;sence d&rsquo;ict&egrave;re ou autres anomalies.</li>
+                </ul>
+            </li>
+            <li>Inspecter les &eacute;quipements autour du patient : stomie, drains, cath&eacute;ters, etc.</li>
+        </ul>
+
+        <h2>3. Palpation</h2>
+        <ul>
+            <li>V&eacute;rifier si l&rsquo;abdomen est souple ou non.</li>
+            <li>Identifier une d&eacute;fense ou une contracture.</li>
+            <li>D&eacute;tecter une sensibilit&eacute; localis&eacute;e.</li>
+            <li>Palper pour rechercher :
+                <ul>
+                    <li>H&eacute;patom&eacute;galie (mesurer la fl&egrave;che si pr&eacute;sente).</li>
+                    <li>Spl&eacute;nom&eacute;galie.</li>
+                    <li>Masse abdominale ou autre anomalie.</li>
+                </ul>
+            </li>
+            <li>Palpation sp&eacute;cifique :
+                <ul>
+                    <li>Orifices herniaires.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>4. Percussion</h2>
+        <p style="font-size:0.9em; color:var(--subtext); margin-bottom:8px;"><em>D&eacute;limiter les organes et d&eacute;tecter les anomalies.</em></p>
+        <ul>
+            <li>Tympanisme ou matit&eacute; sur les neuf r&eacute;gions.</li>
+            <li>Signe du flot (pr&eacute;sence d&rsquo;ascite).</li>
+            <li>Signe du gla&ccedil;on pour une masse mobile.</li>
+        </ul>
+
+        <h2>5. Auscultation</h2>
+        <p style="font-size:0.9em; color:var(--subtext); margin-bottom:8px;"><em>&Eacute;couter les bruits abdominaux.</em></p>
+        <ul>
+            <li>Rechercher des bruits hydro-a&eacute;riques (pr&eacute;sents ou absents).</li>
+            <li>Identifier un souffle abdominal :
+                <ul>
+                    <li>Aortique.</li>
+                    <li>R&eacute;nal.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>6. Toucher rectal</h2>
+        <ul>
+            <li>Inspection externe : fissures, h&eacute;morro&iuml;des, fistules, excoriations.</li>
+            <li>&Eacute;valuation interne :
+                <ul>
+                    <li>Tonus sphinct&eacute;rien.</li>
+                    <li>Masse ou f&eacute;calome dans l&rsquo;ampoule rectale.</li>
+                    <li>Palpation de la prostate (chez l&rsquo;homme).</li>
+                </ul>
+            </li>
+            <li>&Eacute;tat du doigtier apr&egrave;s examen : sang, pus, etc.</li>
+            <li>Recherche du cri de Douglas.</li>
+        </ul>
+
+        <h2>7. Fin de l&rsquo;examen</h2>
+        <ul>
+            <li>Informer le patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remercier le patient pour sa coop&eacute;ration.</li>
+            <li>R&eacute;sumer vos conclusions et proposer des investigations compl&eacute;mentaires si n&eacute;cessaire.</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/PzaQruyoRe-SooWsi0j-cg" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/Général.html
+++ b/clinXpert/Général.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen General - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container {
+        max-width: 820px;
+        margin: 0 auto;
+    }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#9881; Examen General</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/UsapZtdGeNk"
+                    title="Examen General"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. &Eacute;valuation initiale</h2>
+        <ul>
+            <li>Niveau de conscience :
+                <ul>
+                    <li>&Eacute;valuer avec le score de Glasgow.</li>
+                </ul>
+            </li>
+            <li>Apparence g&eacute;n&eacute;rale :
+                <ul>
+                    <li>&Eacute;tat de sant&eacute; apparent.</li>
+                    <li>Coloration : rechercher des signes de p&acirc;leur, cyanose, &eacute;ryth&egrave;me, ict&egrave;re.</li>
+                </ul>
+            </li>
+            <li>Constantes vitales :
+                <ul>
+                    <li>Tension art&eacute;rielle : mesurer aux deux bras.</li>
+                    <li>Fr&eacute;quence cardiaque : pouls radial (fr&eacute;quence, rythme).</li>
+                    <li>Fr&eacute;quence respiratoire.</li>
+                    <li>Temp&eacute;rature.</li>
+                    <li>Taille, poids, IMC.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>2. &Eacute;tat g&eacute;n&eacute;ral</h2>
+        <ul>
+            <li>Recherche de signes :
+                <ul>
+                    <li>D&eacute;shydratation : v&eacute;rifier le pli cutan&eacute; pr&eacute;-sternal.</li>
+                    <li>D&eacute;nutrition : pli cutan&eacute; abdominal.</li>
+                    <li>Signes de choc : marbrures, froideur des extr&eacute;mit&eacute;s, TRC &gt; 3 secondes.</li>
+                    <li>&Eacute;tat des conjonctives (p&acirc;leur, ict&egrave;re).</li>
+                    <li>OMI (&oelig;d&egrave;mes des membres inf&eacute;rieurs).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/ZH8jqc3kQU6u1JykDD6KNg" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/cardio-vasculaire.html
+++ b/clinXpert/cardio-vasculaire.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Cardio-vasculaire - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#10084; Examen Cardio-vasculaire</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/ovV2wSxrxVg"
+                    title="Examen Cardiovasculaire"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez le nom et la date de naissance du patient.</li>
+            <li>Expliquez l&rsquo;examen avec des mots simples.</li>
+            <li>Obtenez le consentement du patient.</li>
+            <li>Ajustez le lit &agrave; 45&deg; et exposez le thorax.</li>
+            <li>Demandez si le patient ressent une douleur avant de continuer.</li>
+        </ul>
+
+        <h2>2. Inspection g&eacute;n&eacute;rale</h2>
+        <ul>
+            <li>Recherchez des signes cliniques :
+                <ul>
+                    <li>D&eacute;formations thoraciques.</li>
+                    <li>Cicatrices chirurgicales.</li>
+                    <li>Cyanose ou p&acirc;leur.</li>
+                    <li>Turgescence des veines jugulaires.</li>
+                    <li>&OElig;d&egrave;me des membres inf&eacute;rieurs.</li>
+                    <li>Circulation collat&eacute;rale veineuse thoracique.</li>
+                </ul>
+            </li>
+            <li>Notez les &eacute;quipements pr&eacute;sents : cath&eacute;ters, pansements, etc.</li>
+        </ul>
+
+        <h2>3. Palpation</h2>
+        <ul>
+            <li>Choc de pointe : position et caract&egrave;re (punctiforme, &eacute;tal&eacute; ou d&eacute;plac&eacute;).</li>
+            <li>Fr&eacute;missement (thrills).</li>
+            <li>Signe de Harzer.</li>
+            <li>Reflux h&eacute;pato-jugulaire.</li>
+        </ul>
+
+        <h2>4. Auscultation</h2>
+        <ul>
+            <li>V&eacute;rifiez le rythme cardiaque : r&eacute;gulier ou non.</li>
+            <li>Bruits cardiaques :
+                <ul>
+                    <li>B1 et B2 bien per&ccedil;us.</li>
+                    <li>Recherche de souffles ou bruits surajout&eacute;s.</li>
+                    <li>Caract&eacute;riser le souffle : si&egrave;ge, temps (proto-m&eacute;so-t&eacute;l&eacute;-holo : systolique/diastolique), timbre, irradiation, variabilit&eacute; (respiratoire/positionnelle).</li>
+                </ul>
+            </li>
+            <li>Utilisez les man&oelig;uvres positionnelles et respiratoires pour affiner (expiration, d&eacute;cubitus lat&eacute;ral).</li>
+            <li>Auscultation des axes vasculaires (carotides).</li>
+            <li>Auscultation pulmonaire (r&acirc;les cr&eacute;pitants).</li>
+        </ul>
+
+        <h2>5. Examen vasculaire</h2>
+        <ul>
+            <li>Pr&eacute;sence et sym&eacute;trie des pouls.</li>
+            <li>V&eacute;rifiez les pouls : radial, ulnaire, brachial, carotidien, aortique, f&eacute;moral, poplit&eacute;, tibial post&eacute;rieur et p&eacute;dieux.</li>
+            <li>Auscultation des gros axes : carotidiens, f&eacute;moraux, aortique &mdash; souffle ?</li>
+        </ul>
+
+        <h2>6. Signes p&eacute;riph&eacute;riques</h2>
+        <h3>Mains</h3>
+        <ul>
+            <li>Couleur, temp&eacute;rature, xanthomes, hippocratisme digital.</li>
+            <li>Temps de remplissage capillaire (TRC).</li>
+        </ul>
+        <h3>Jugulaire</h3>
+        <ul>
+            <li>Mesurez la JVP correctement positionn&eacute;e.</li>
+            <li>V&eacute;rifiez le reflux h&eacute;pato-jugulaire.</li>
+        </ul>
+        <h3>Visage</h3>
+        <ul>
+            <li>Yeux : p&acirc;leur conjonctivale, arc corn&eacute;en, xanth&eacute;lasma.</li>
+            <li>Bouche : cyanose centrale, mauvaise hygi&egrave;ne dentaire.</li>
+        </ul>
+
+        <h2>7. Finalisation et examen compl&eacute;mentaire</h2>
+        <ul>
+            <li>Inspectez le dos pour les cicatrices ou d&eacute;formations.</li>
+            <li>Auscultez les bases pulmonaires.</li>
+            <li>Palpez les chevilles et le sacrum pour un &oelig;d&egrave;me.</li>
+        </ul>
+
+        <h2>8. Conclusion</h2>
+        <ul>
+            <li>Expliquez au patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez le patient.</li>
+            <li>Lavez vos mains.</li>
+            <li>R&eacute;sumez vos observations et sugg&eacute;rez des investigations compl&eacute;mentaires.</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/8VfzDMAtQ2mgeKTloVoneA" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/gynécologique.html
+++ b/clinXpert/gynécologique.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Gynecologique - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#9792; Examen Gyn&eacute;cologique</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/IM8mhMT77IE"
+                    title="Examen Gynecologique"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez l&rsquo;identit&eacute; de la patiente (nom et date de naissance).</li>
+            <li>Expliquez l&rsquo;examen en termes simples et rassurants.</li>
+            <li>Obtenez le consentement pour continuer.</li>
+        </ul>
+
+        <h2>2. Examen abdominal</h2>
+        <h3>Inspection</h3>
+        <ul>
+            <li>Recherchez des cicatrices chirurgicales.</li>
+            <li>V&eacute;rifiez la pr&eacute;sence de hernies ou de voussures.</li>
+        </ul>
+        <h3>Palpation</h3>
+        <ul>
+            <li>Masse abdominale palpable.</li>
+            <li>Zones de sensibilit&eacute; ou douleur.</li>
+        </ul>
+
+        <h2>3. Examen des seins</h2>
+        <h3>Inspection (positions vari&eacute;es)</h3>
+        <ul>
+            <li>Face, profil, mains sur les hanches, pench&eacute;e en avant.</li>
+            <li>Taille, forme.</li>
+            <li>Anomalies : peau d&rsquo;orange, rougeurs, mamelon ombiliqu&eacute;, d&eacute;formation, maladie de Paget.</li>
+        </ul>
+        <h3>Palpation</h3>
+        <ul>
+            <li>Position en d&eacute;cubitus dorsal, main sous la t&ecirc;te, les 4 quadrants syst&eacute;matiquement examin&eacute;s.</li>
+            <li>Recherche de nodules, zones douloureuses, mastose, &eacute;coulements mamelonnaires.</li>
+            <li>Palpation des aires ganglionnaires axillaires, sus-claviculaires et cervicales.</li>
+        </ul>
+
+        <h2>4. Examen pelvi-p&eacute;rin&eacute;al</h2>
+        <h3>Inspection</h3>
+        <ul>
+            <li>Aspect des organes g&eacute;nitaux externes : trophicit&eacute;, pilosit&eacute;, pigmentation, d&eacute;veloppement des grandes et petites l&egrave;vres, clitoris.</li>
+            <li>S&eacute;quelles obst&eacute;tricales : &eacute;pisiotomies, d&eacute;chirures, fistules.</li>
+            <li>Distance ano-vulvaire.</li>
+            <li>Effort de toux pour &eacute;valuer un prolapsus.</li>
+        </ul>
+        <h3>Palpation vulvaire</h3>
+        <ul>
+            <li>Masse ou nodule.</li>
+        </ul>
+
+        <h2>5. Examen au sp&eacute;culum</h2>
+        <h3>Pr&eacute;paration</h3>
+        <ul>
+            <li>Pr&eacute;parez le sp&eacute;culum et lubrifiez-le au s&eacute;rum physiologique sans toucher les lames.</li>
+        </ul>
+        <h3>Insertion</h3>
+        <ul>
+            <li>&Eacute;cartez les l&egrave;vres avec la main non dominante.</li>
+            <li>Ins&eacute;rez doucement le sp&eacute;culum (lames ferm&eacute;es, poign&eacute;e lat&eacute;rale).</li>
+            <li>Tournez la poign&eacute;e vers le haut une fois ins&eacute;r&eacute;.</li>
+            <li>Ouvrez les lames et verrouillez-les pour visualiser le col ut&eacute;rin.</li>
+        </ul>
+        <h3>Observation</h3>
+        <ul>
+            <li>Col : forme, taille, &eacute;coulement, glaire cervicale (quantit&eacute;, transparence, filance).</li>
+            <li>Vagin : anomalies visibles.</li>
+        </ul>
+        <h3>Retrait</h3>
+        <ul>
+            <li>Rel&acirc;chez doucement le sp&eacute;culum en inspectant les parois vaginales.</li>
+        </ul>
+
+        <h2>6. Toucher vaginal (TV) avec palpation abdominale</h2>
+        <ul>
+            <li>Col ut&eacute;rin :
+                <ul>
+                    <li>Longueur, mobilit&eacute;, sensibilit&eacute;.</li>
+                </ul>
+            </li>
+            <li>Ut&eacute;rus :
+                <ul>
+                    <li>Taille, position, consistance, mobilit&eacute;.</li>
+                </ul>
+            </li>
+            <li>Annexes :
+                <ul>
+                    <li>Palpation pour masses ou douleurs.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>7. Conclusion et finalisation de l&rsquo;examen</h2>
+        <ul>
+            <li>Expliquez &agrave; la patiente que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez la patiente pour sa coop&eacute;ration.</li>
+            <li>Fournissez un espace priv&eacute; pour que la patiente se rhabille.</li>
+            <li>Lavez vos mains et &eacute;liminez les EPI.</li>
+            <li>R&eacute;sumez vos observations.</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/HzCGu5ijR-CscB.oVfGTxg" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/neurologique.html
+++ b/clinXpert/neurologique.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Neurologique - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#129504; Examen Neurologique</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/Us4BapUPRJw"
+                    title="Examen Neurologique"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez l&rsquo;identit&eacute; du patient (nom et date de naissance).</li>
+            <li>Expliquez ce que l&rsquo;examen neurologique impliquera en termes simples et rassurants.</li>
+            <li>V&eacute;rifiez si le patient a des douleurs ou des g&ecirc;nes avant de commencer.</li>
+            <li>Obtenez le consentement pour proc&eacute;der.</li>
+            <li>Positionnez le patient selon les &eacute;tapes n&eacute;cessaires (debout, assis ou couch&eacute;).</li>
+        </ul>
+
+        <h2>2. &Eacute;tude de la marche et de l&rsquo;&eacute;quilibre</h2>
+        <ul>
+            <li>Observez la marche normale : sym&eacute;trie, fluidit&eacute;, coordination.</li>
+            <li>&Eacute;valuez la d&eacute;marche en tandem (talon-pointe).</li>
+            <li>Recherchez un signe de Romberg :
+                <ul>
+                    <li>Yeux ouverts puis ferm&eacute;s.</li>
+                    <li>Oscillation + chute = Romberg positif (atteinte proprioceptive).</li>
+                    <li>Oscillation sans chute = Romberg n&eacute;gatif (atteinte c&eacute;r&eacute;belleuse).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>3. &Eacute;tude des fonctions sup&eacute;rieures</h2>
+        <ul>
+            <li>&Eacute;valuez :
+                <ul>
+                    <li>Langage (compr&eacute;hension, expression).</li>
+                    <li>M&eacute;moire (imm&eacute;diate, diff&eacute;r&eacute;e).</li>
+                    <li>Orientation spatio-temporelle.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>4. Examen des nerfs cr&acirc;niens</h2>
+        <ul>
+            <li>NC I (Olfactif) :
+                <ul><li>Caf&eacute;, vanille...</li></ul>
+            </li>
+            <li>NC II (Optique) :
+                <ul><li>Inspectez les pupilles, testez l&rsquo;acuit&eacute; visuelle, champs visuels et r&eacute;flexes pupillaires.</li></ul>
+            </li>
+            <li>NC III, IV, VI (Oculomoteurs) :
+                <ul>
+                    <li>Inspectez les paupi&egrave;res pour un ptosis.</li>
+                    <li>&Eacute;valuez les mouvements oculaires et recherchez un strabisme.</li>
+                </ul>
+            </li>
+            <li>NC V (Trijumeau) :
+                <ul>
+                    <li>Testez la sensibilit&eacute; faciale (front, joue, menton).</li>
+                    <li>Palpez les muscles masticateurs.</li>
+                    <li>Testez le r&eacute;flexe corn&eacute;en.</li>
+                </ul>
+            </li>
+            <li>NC VII (Facial) :
+                <ul>
+                    <li>Observez les asym&eacute;tries faciales.</li>
+                    <li>Testez les expressions faciales (sourire, froncement de sourcils).</li>
+                </ul>
+            </li>
+            <li>NC VIII (Cochl&eacute;o-vestibulaire) :
+                <ul>
+                    <li>&Eacute;valuez l&rsquo;audition.</li>
+                    <li>Testez la fonction vestibulaire : Romberg.</li>
+                </ul>
+            </li>
+            <li>NC IX et X (Glosso-pharyngien et Vague) :
+                <ul><li>Testez la phonation (&laquo;&nbsp;ahh&nbsp;&raquo;), le r&eacute;flexe naus&eacute;eux et la d&eacute;glutition.</li></ul>
+            </li>
+            <li>NC XI (Accessoire) :
+                <ul><li>&Eacute;valuez la force du trap&egrave;ze et du SCM.</li></ul>
+            </li>
+            <li>NC XII (Hypoglosse) :
+                <ul><li>Observez la langue pour atrophie, fasciculations et d&eacute;viation.</li></ul>
+            </li>
+        </ul>
+
+        <h2>5. Examen moteur</h2>
+        <h3>Inspection</h3>
+        <ul>
+            <li>Recherchez une amyotrophie, des mouvements anormaux (tremblements, fasciculations).</li>
+        </ul>
+        <h3>Tonus</h3>
+        <ul>
+            <li>&Eacute;valuez le tonus musculaire (hypertonie spastique ou plastique).</li>
+            <li>Recherchez un clonus &agrave; la cheville, roue dent&eacute;e.</li>
+        </ul>
+        <h3>Force musculaire</h3>
+        <ul>
+            <li>Testez globalement :
+                <ul>
+                    <li>&Eacute;preuve de Barr&eacute; (MS).</li>
+                    <li>&Eacute;preuve de Mingazzini (MI).</li>
+                </ul>
+            </li>
+            <li>Testez par segment selon l&rsquo;&eacute;chelle MRC (0 &agrave; 5) pour :
+                <ul>
+                    <li>&Eacute;paules, coudes, poignets, doigts (MS).</li>
+                    <li>Hanches, genoux, chevilles, orteils (MI).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>6. Examen sensitif</h2>
+        <ul>
+            <li>Testez :
+                <ul>
+                    <li>Sensibilit&eacute; tactile fine (coton).</li>
+                    <li>Sensibilit&eacute; douloureuse (piq&ucirc;re d&rsquo;&eacute;pingle).</li>
+                    <li>Sensibilit&eacute; vibratoire (diapason).</li>
+                    <li>Sensibilit&eacute; proprioceptive (mouvement passif d&rsquo;un doigt ou d&rsquo;un orteil).</li>
+                </ul>
+            </li>
+            <li>&Eacute;valuez la sensibilit&eacute; dermatome par dermatome.</li>
+        </ul>
+
+        <h2>7. &Eacute;tude de la coordination</h2>
+        <ul>
+            <li>Testez :
+                <ul>
+                    <li>&Eacute;preuve doigt-nez : dysm&eacute;trie, hyperm&eacute;trie, dyschronom&eacute;trie.</li>
+                    <li>&Eacute;preuve talon-genou : incoordination au MI.</li>
+                    <li>Dysdiadochocin&eacute;sie (mouvements altern&eacute;s rapides).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>8. &Eacute;tude des r&eacute;flexes</h2>
+        <h3>R&eacute;flexes ost&eacute;o-tendineux</h3>
+        <ul>
+            <li>Bicipital, tricipital, stylo-radial (MS).</li>
+            <li>Rotulien, achill&eacute;en (MI).</li>
+        </ul>
+        <h3>R&eacute;flexes cutan&eacute;s</h3>
+        <ul>
+            <li>R&eacute;flexe cutan&eacute; plantaire : flexion ou signe de Babinski (extension pathologique).</li>
+        </ul>
+
+        <h2>9. Recherche des signes m&eacute;ning&eacute;s</h2>
+        <ul>
+            <li>Raideur de nuque : incapacit&eacute; de fl&eacute;chir le cou.</li>
+            <li>Signe de Kernig : douleur en extension du genou en position de flexion de la hanche.</li>
+            <li>Signe de Brudzinski : flexion des genoux lors de la flexion de la nuque.</li>
+        </ul>
+
+        <h2>10. Conclusion</h2>
+        <ul>
+            <li>Expliquez au patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez le patient pour sa coop&eacute;ration.</li>
+            <li>Lavez vos mains et &eacute;liminez les EPI.</li>
+            <li>R&eacute;sumez vos observations et proposez des investigations compl&eacute;mentaires (imagerie, examens &eacute;lectrophysiologiques, etc.).</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/67OruJs.T7Cqf64oEvJZMg" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/ostéoarticulaire.html
+++ b/clinXpert/ostéoarticulaire.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Osteo-articulaire - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#129471; Examen Ost&eacute;o-articulaire</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/KU9tNia7NYo"
+                    title="Examen Osteoarticulaire"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez l&rsquo;identit&eacute; du patient (nom et date de naissance).</li>
+            <li>Expliquez ce que l&rsquo;examen impliquera avec des termes simples et rassurants.</li>
+            <li>Obtenez le consentement pour proc&eacute;der.</li>
+            <li>V&eacute;rifiez si le patient ressent une douleur avant de commencer.</li>
+        </ul>
+
+        <h2>2. Inspection g&eacute;n&eacute;rale</h2>
+        <ul>
+            <li>Observez le patient de face, de c&ocirc;t&eacute; et de dos :
+                <ul>
+                    <li>Alignement corporel.</li>
+                    <li>D&eacute;formations ou asym&eacute;tries.</li>
+                    <li>Signes de maladies syst&eacute;miques (amyotrophies, cicatrices, rougeurs).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>3. GALS Screen</h2>
+        <p style="font-size:0.9em; color:var(--subtext); margin-bottom:8px;"><em>&Eacute;valuation g&eacute;n&eacute;rale des articulations.</em></p>
+        <ul>
+            <li>Marche : fluidit&eacute;, sym&eacute;trie, anomalies de la marche.</li>
+            <li>Membres sup&eacute;rieurs :
+                <ul>
+                    <li>Flexion, extension, mouvements combin&eacute;s.</li>
+                    <li>V&eacute;rifiez la force de pr&eacute;hension et les mouvements fins.</li>
+                    <li>Squeeze test (PR).</li>
+                </ul>
+            </li>
+            <li>Membres inf&eacute;rieurs :
+                <ul>
+                    <li>Flexion/extension passives des genoux.</li>
+                    <li>Rotation interne des hanches.</li>
+                    <li>Squeeze test.</li>
+                </ul>
+            </li>
+            <li>Rachis :
+                <ul>
+                    <li>Courbures : lordose, cyphose.</li>
+                    <li>Cervical : flexion, extension, rotation, inclinaison lat&eacute;rale.</li>
+                    <li>Thoracique : ampliation thoracique.</li>
+                    <li>Lombaire : flexion (distance doigt-sol), extension, rotation, indice de Sch&ouml;ber.</li>
+                    <li>Tests radiculaires :
+                        <ul>
+                            <li>Signe de Las&egrave;gue (rachis lombaire).</li>
+                            <li>Signe de L&eacute;ri (rachis lombaire).</li>
+                        </ul>
+                    </li>
+                    <li>Examen des sacro-iliaques :
+                        <ul>
+                            <li>Palpation de l&rsquo;interligne.</li>
+                            <li>Signe du Tr&eacute;pied.</li>
+                            <li>Test d&rsquo;&eacute;cartement / rapprochement.</li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>4. Examen de l&rsquo;&eacute;paule</h2>
+        <h3>Tests sp&eacute;cifiques</h3>
+        <ul>
+            <li>Recherche de conflit sous-acromial :
+                <ul>
+                    <li>Test de Neer.</li>
+                    <li>Test de Hawkins.</li>
+                    <li>Test de Yocum.</li>
+                </ul>
+            </li>
+            <li>Recherche de tendinopathie sp&eacute;cifique :
+                <ul>
+                    <li>Test de Jobe : muscle supra-&eacute;pineux.</li>
+                    <li>Test de Patte : muscle infra-&eacute;pineux et petit rond.</li>
+                    <li>Palm-up test : long biceps.</li>
+                    <li>Belly press test : muscle sous-scapulaire.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>5. Examen de la hanche</h2>
+        <h3>Tests sp&eacute;cifiques</h3>
+        <ul>
+            <li>Boiterie.</li>
+            <li>Trendelenburg : faiblesse des abducteurs.</li>
+            <li>Test de Thomas : d&eacute;formation en flexion fixe.</li>
+            <li>Man&oelig;uvre du salut coxal : incapacit&eacute; de maintenir le MI tendu &agrave; 30&deg; du lit.</li>
+        </ul>
+
+        <h2>6. Examen du genou</h2>
+        <h3>Palpation</h3>
+        <ul>
+            <li>Palpez l&rsquo;articulation en extension et flexion : cr&eacute;pitations.</li>
+            <li>Signe du flot, choc rotulien.</li>
+        </ul>
+        <h3>Mouvements</h3>
+        <ul>
+            <li>Flexion et extension (actives et passives).</li>
+        </ul>
+        <h3>Tests sp&eacute;cifiques</h3>
+        <ul>
+            <li>Tiroir ant&eacute;rieur/post&eacute;rieur : ligaments crois&eacute;s.</li>
+            <li>McMurray : atteinte m&eacute;niscale.</li>
+            <li>Zohlen et Rabot : atteinte f&eacute;moro-patellaire.</li>
+        </ul>
+
+        <h2>7. Conclusion</h2>
+        <ul>
+            <li>Expliquez au patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez le patient pour sa coop&eacute;ration.</li>
+            <li>Lavez vos mains.</li>
+            <li>R&eacute;sumez vos observations.</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/wgw975SfSyucdJommAvJ2A" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/pleuro-pulmonaire.html
+++ b/clinXpert/pleuro-pulmonaire.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Pleuro-pulmonaire - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#127787; Examen Pleuro-pulmonaire</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/mAjc1TGxgtE"
+                    title="Examen Pleuropulmonaire"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez l&rsquo;identit&eacute; du patient (nom et date de naissance).</li>
+            <li>Expliquez l&rsquo;examen avec des termes simples et rassurants.</li>
+            <li>Obtenez le consentement pour proc&eacute;der.</li>
+            <li>Demandez si le patient ressent une douleur ou une g&ecirc;ne respiratoire avant de continuer.</li>
+        </ul>
+
+        <h2>2. Inspection</h2>
+        <ul>
+            <li>Recherchez des signes de gravit&eacute; :
+                <ul>
+                    <li>Cyanose.</li>
+                    <li>D&eacute;tresse respiratoire.</li>
+                    <li>Fr&eacute;quence respiratoire (tachypn&eacute;e ou bradypn&eacute;e).</li>
+                </ul>
+            </li>
+            <li>Observez les mains :
+                <ul>
+                    <li>Taches de goudron.</li>
+                    <li>Hippocratisme digital.</li>
+                </ul>
+            </li>
+            <li>V&eacute;rifiez :
+                <ul>
+                    <li>Turgescence des veines jugulaires (TVJ).</li>
+                    <li>Distension thoracique.</li>
+                    <li>Circulation veineuse collat&eacute;rale thoracique.</li>
+                    <li>Sym&eacute;trie thoracique ou non.</li>
+                    <li>Pr&eacute;sence de cicatrices chirurgicales thoraciques.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>3. Palpation</h2>
+        <ul>
+            <li>Vibrations vocales (bien transmises ou diminu&eacute;es).</li>
+            <li>Expansion thoracique (sym&eacute;trique ou r&eacute;duite).</li>
+        </ul>
+
+        <h2>4. Percussion</h2>
+        <ul>
+            <li>Notez la sonorit&eacute; thoracique :
+                <ul>
+                    <li>Normale (sonore).</li>
+                    <li>Matit&eacute; (&eacute;panchement pleural).</li>
+                    <li>Tympanisme (pneumothorax).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>5. Auscultation</h2>
+        <ul>
+            <li>&Eacute;valuez le murmure v&eacute;siculaire :
+                <ul>
+                    <li>Pr&eacute;sent, diminu&eacute; ou absent.</li>
+                </ul>
+            </li>
+            <li>Recherchez des r&acirc;les :
+                <ul>
+                    <li>Sibilants (obstruction bronchique : asthme ou BPCO).</li>
+                    <li>Cr&eacute;pitants (&oelig;d&egrave;me pulmonaire, pneumonie, fibrose).</li>
+                    <li>Ronflants (s&eacute;cr&eacute;tions bronchiques).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>6. Finalisation</h2>
+        <ul>
+            <li>V&eacute;rifiez la pr&eacute;sence de :
+                <ul>
+                    <li>&OElig;d&egrave;me sacr&eacute; et des membres inf&eacute;rieurs.</li>
+                    <li>Ballotement du mollet (TVP).</li>
+                    <li>Signe de Homans (TVP).</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>7. Conclusion</h2>
+        <ul>
+            <li>Expliquez au patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez le patient.</li>
+            <li>Lavez vos mains et &eacute;liminez l&rsquo;EPI.</li>
+            <li>R&eacute;sumez vos observations et proposez les examens compl&eacute;mentaires n&eacute;cessaires.</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/hZs71-PyQcygkBtJWaPWwA" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/clinXpert/urologique.html
+++ b/clinXpert/urologique.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Examen Urologique - Guide clinXpert</title>
+<style>
+    :root {
+        --blue: #0056b3;
+        --blue-light: #e8f0fc;
+        --blue-dark: #0d3d72;
+        --gray: #6c757d;
+        --border: #dee2e6;
+        --bg: #f0f2f5;
+        --card-bg: #fff;
+        --text: #212529;
+        --subtext: #495057;
+        --radius: 12px;
+        --shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        padding: 20px;
+        padding-top: 80px;
+        line-height: 1.5;
+    }
+    .top-nav {
+        position: fixed;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        background: rgba(20,20,20,0.88);
+        backdrop-filter: blur(10px);
+        -webkit-backdrop-filter: blur(10px);
+        border-radius: 50px;
+        padding: 8px 16px;
+        box-shadow: 0 6px 18px rgba(0,0,0,0.25);
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+    .top-nav a {
+        color: #fff;
+        text-decoration: none;
+        padding: 6px 14px;
+        border-radius: 30px;
+        font-size: 0.9em;
+        font-weight: 500;
+        transition: background-color 0.2s;
+    }
+    .top-nav a:hover { background-color: rgba(255,255,255,0.15); }
+    .top-nav .brand {
+        font-family: 'Papyrus', 'Segoe Script', fantasy;
+        font-size: 0.95em;
+        color: #fff;
+        letter-spacing: 1px;
+    }
+    .container { max-width: 820px; margin: 0 auto; }
+    .page-title {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 2em;
+        color: var(--blue-dark);
+        text-align: center;
+        margin-bottom: 20px;
+        letter-spacing: 1.5px;
+    }
+    .card {
+        background: var(--card-bg);
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        padding: 22px;
+        margin-bottom: 20px;
+    }
+    .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        height: 0;
+        overflow: hidden;
+        border-radius: var(--radius);
+    }
+    .video-container iframe {
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        border: 0;
+    }
+    .guide h2 {
+        font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        font-size: 1.3em;
+        color: var(--blue);
+        margin: 22px 0 10px;
+        padding-bottom: 6px;
+        border-bottom: 2px solid var(--blue-light);
+        letter-spacing: 1px;
+    }
+    .guide h2:first-child { margin-top: 0; }
+    .guide h3 {
+        font-size: 1em;
+        color: var(--blue-dark);
+        margin: 14px 0 6px;
+        font-weight: 600;
+    }
+    .guide ul {
+        list-style-type: disc;
+        padding-left: 22px;
+        margin-bottom: 8px;
+    }
+    .guide ul ul { list-style-type: circle; margin-top: 4px; }
+    .guide ul ul ul { list-style-type: square; }
+    .guide li {
+        font-size: 0.95em;
+        line-height: 1.55;
+        margin-bottom: 4px;
+        color: var(--text);
+    }
+    .source {
+        margin-top: 22px;
+        padding-top: 14px;
+        border-top: 1px dashed var(--border);
+        font-size: 0.82em;
+        color: var(--gray);
+        text-align: center;
+    }
+    .source a { color: var(--blue); text-decoration: none; }
+    .source a:hover { text-decoration: underline; }
+    @media (max-width: 500px) {
+        body { padding: 12px; padding-top: 75px; }
+        .card { padding: 16px; }
+        .page-title { font-size: 1.6em; }
+        .guide h2 { font-size: 1.15em; }
+    }
+</style>
+</head>
+<body>
+
+<div class="top-nav">
+    <a href="../index.html">&#8592; Accueil</a>
+    <span class="brand">clinXpert</span>
+</div>
+
+<div class="container">
+    <h1 class="page-title">&#128167; Examen Urologique</h1>
+
+    <div class="card">
+        <div class="video-container">
+            <iframe src="https://www.youtube.com/embed/P7lr3NQgwzY"
+                    title="Examen Urologique"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen></iframe>
+        </div>
+    </div>
+
+    <div class="card guide">
+        <h2>1. Introduction</h2>
+        <ul>
+            <li>Lavez vos mains et portez des gants propres.</li>
+            <li>Pr&eacute;sentez-vous avec votre nom et r&ocirc;le.</li>
+            <li>Confirmez l&rsquo;identit&eacute; du patient (nom et date de naissance).</li>
+            <li>Expliquez l&rsquo;examen en termes simples et rassurants.</li>
+            <li>Obtenez le consentement pour l&rsquo;examen.</li>
+            <li>Fournissez de l&rsquo;intimit&eacute; pour que le patient se d&eacute;shabille si n&eacute;cessaire.</li>
+            <li>Demandez si le patient ressent une douleur avant de commencer.</li>
+        </ul>
+
+        <h2>2. Inspection g&eacute;n&eacute;rale</h2>
+        <ul>
+            <li>Notez l&rsquo;aspect des urines :
+                <ul>
+                    <li>H&eacute;maturie.</li>
+                    <li>Pyurie.</li>
+                </ul>
+            </li>
+            <li>Recherchez des signes cliniques g&eacute;n&eacute;raux :
+                <ul>
+                    <li>Cicatrices abdominales ou lombaires.</li>
+                    <li>&OElig;d&egrave;me des membres inf&eacute;rieurs.</li>
+                    <li>Voussure lombaire.</li>
+                </ul>
+            </li>
+        </ul>
+
+        <h2>3. Examen des fosses lombaires</h2>
+        <h3>Inspection</h3>
+        <ul>
+            <li>Voussure lombaire.</li>
+            <li>Cicatrices chirurgicales.</li>
+        </ul>
+        <h3>Palpation</h3>
+        <ul>
+            <li>Contact lombaire : masse per&ccedil;ue au contact de la paroi post&eacute;rieure.</li>
+            <li>Ballottement r&eacute;nal : impulsions transmises entre les mains ant&eacute;rieure et post&eacute;rieure.</li>
+        </ul>
+        <h3>Percussion</h3>
+        <ul>
+            <li>Signe de Giordano : emp&acirc;tement douloureux &agrave; la percussion lombaire (oriente vers une PNA).</li>
+        </ul>
+
+        <h2>4. Examen de l&rsquo;hypogastre</h2>
+        <p style="font-size:0.9em; color:var(--subtext); margin-bottom:8px;"><em>Recherche de globe v&eacute;sical.</em></p>
+        <h3>Inspection</h3>
+        <ul><li>Voussure sus-pubienne.</li></ul>
+        <h3>Palpation</h3>
+        <ul><li>Masse hypogastrique palpable.</li></ul>
+        <h3>Percussion</h3>
+        <ul><li>Matit&eacute; &agrave; bord sup&eacute;rieur convexe.</li></ul>
+
+        <h2>5. Examen des organes g&eacute;nitaux externes</h2>
+        <h3>Chez l&rsquo;homme</h3>
+        <ul>
+            <li>Verge : position du m&eacute;at ur&eacute;tral, &eacute;coulement ur&eacute;tral, &oelig;d&egrave;me ou h&eacute;matome, induration du corps caverneux.</li>
+            <li>Scrotum :
+                <ul>
+                    <li>Aspect de la peau scrotale (hernie inguino-scrotale, hydroc&egrave;le, cryptorchidie, varicoc&egrave;le).</li>
+                    <li>Transillumination syst&eacute;matique :
+                        <ul>
+                            <li>Masse liquidienne (positive).</li>
+                            <li>Masse tissulaire (n&eacute;gative).</li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
+            <li>Cordon spermatique :
+                <ul>
+                    <li>Volume, consistance.</li>
+                    <li>Recherche de varicoc&egrave;le (remplissage debout avec effort de toux).</li>
+                </ul>
+            </li>
+            <li>Signe de Prehn : orchi-&eacute;pididymite.</li>
+            <li>R&eacute;flexe cr&eacute;mast&eacute;rien : aboli si torsion testiculaire.</li>
+        </ul>
+        <h3>Chez la femme</h3>
+        <ul>
+            <li>Grandes et petites l&egrave;vres : rougeur, l&eacute;sion.</li>
+            <li>M&eacute;at ur&eacute;tral : &eacute;coulement ou anomalie.</li>
+        </ul>
+
+        <h2>6. Toucher rectal</h2>
+        <ul>
+            <li>&Eacute;valuer le tonus anal.</li>
+            <li>Prostate :
+                <ul>
+                    <li>Normale : petite saillie avec deux lobes et un sillon m&eacute;dian.</li>
+                    <li>Augment&eacute;e, souple et indolore (hypertrophie b&eacute;nigne).</li>
+                    <li>Douloureuse (prostatite).</li>
+                    <li>Dure et irr&eacute;guli&egrave;re (cancer).</li>
+                </ul>
+            </li>
+            <li>Recherche d&rsquo;ad&eacute;nopathies inguinales.</li>
+        </ul>
+
+        <h2>7. Conclusion</h2>
+        <ul>
+            <li>Expliquez au patient que l&rsquo;examen est termin&eacute;.</li>
+            <li>Remerciez le patient.</li>
+            <li>Lavez vos mains et &eacute;liminez l&rsquo;EPI.</li>
+            <li>R&eacute;sumez vos observations et proposez les investigations n&eacute;cessaires (&eacute;chographie, analyses urinaires, etc.).</li>
+        </ul>
+
+        <div class="source">
+            Source : <a href="https://clinxpert.glide.page/dl/ClinXpert/s/85159a/r/BxsBtMwpSpKlgPJay-2LqQ" target="_blank">ClinXpert</a>
+        </div>
+    </div>
+</div>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -300,6 +300,16 @@
             text-decoration: underline;
         }
 
+        /* ClinXpert Papyrus styling */
+        .clinxpert-section .section-title,
+        .clinxpert-section .resource-link {
+            font-family: 'Papyrus', 'Segoe Script', 'Comic Sans MS', fantasy;
+        }
+        .clinxpert-section .section-title {
+            font-size: 1em;
+            letter-spacing: 1px;
+        }
+
         /* Responsive */
         @media (max-width: 500px) {
             body { padding: 10px; }
@@ -386,32 +396,34 @@
                 </a>
             </div>
 
-            <div class="section-title">Guides clinXpert</div>
-            <div class="resource-grid">
-                <a href="clinXpert/Général.txt" class="resource-link">
-                    <span class="r-icon">&#9881;</span> General
-                </a>
-                <a href="clinXpert/cardio-vasculaire.txt" class="resource-link">
-                    <span class="r-icon">&#10084;</span> Cardio-vasculaire
-                </a>
-                <a href="clinXpert/neurologique.txt" class="resource-link">
-                    <span class="r-icon">&#129504;</span> Neurologique
-                </a>
-                <a href="clinXpert/Abdominal.txt" class="resource-link">
-                    <span class="r-icon">&#128137;</span> Abdominal
-                </a>
-                <a href="clinXpert/pleuro-pulmonaire.txt" class="resource-link">
-                    <span class="r-icon">&#127787;</span> Pleuro-pulmonaire
-                </a>
-                <a href="clinXpert/ostéoarticulaire.txt" class="resource-link">
-                    <span class="r-icon">&#129471;</span> Osteo-articulaire
-                </a>
-                <a href="clinXpert/gynécologique.txt" class="resource-link">
-                    <span class="r-icon">&#9792;</span> Gynecologique
-                </a>
-                <a href="clinXpert/urologique.txt" class="resource-link">
-                    <span class="r-icon">&#128167;</span> Urologique
-                </a>
+            <div class="clinxpert-section">
+                <div class="section-title">Guides clinXpert</div>
+                <div class="resource-grid">
+                    <a href="clinXpert/Général.html" class="resource-link">
+                        <span class="r-icon">&#9881;</span> General
+                    </a>
+                    <a href="clinXpert/cardio-vasculaire.html" class="resource-link">
+                        <span class="r-icon">&#10084;</span> Cardio-vasculaire
+                    </a>
+                    <a href="clinXpert/neurologique.html" class="resource-link">
+                        <span class="r-icon">&#129504;</span> Neurologique
+                    </a>
+                    <a href="clinXpert/Abdominal.html" class="resource-link">
+                        <span class="r-icon">&#128137;</span> Abdominal
+                    </a>
+                    <a href="clinXpert/pleuro-pulmonaire.html" class="resource-link">
+                        <span class="r-icon">&#127787;</span> Pleuro-pulmonaire
+                    </a>
+                    <a href="clinXpert/ostéoarticulaire.html" class="resource-link">
+                        <span class="r-icon">&#129471;</span> Osteo-articulaire
+                    </a>
+                    <a href="clinXpert/gynécologique.html" class="resource-link">
+                        <span class="r-icon">&#9792;</span> Gynecologique
+                    </a>
+                    <a href="clinXpert/urologique.html" class="resource-link">
+                        <span class="r-icon">&#128167;</span> Urologique
+                    </a>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Convert the 8 clinXpert .txt guides into dedicated HTML pages. Each page embeds the corresponding YouTube tutorial at the top and presents the guide content as structured HTML (headings, nested lists, source link). Apply the Papyrus font to the "Guides clinXpert" section title and buttons on the home page, scoped via a new .clinxpert-section wrapper so other sections keep their original typography.

https://claude.ai/code/session_01CJSK3JF9WsizN9hSJKfgcx