### PR TITLE
Add CONTEXT.md for AI assistants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,115 @@
+# Changelog
+
+Working journal of notable changes. Format adapted from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+**How to read this:**
+- Dates are commit dates (not write dates).
+- `(a3f291)` is a short SHA — `git show a3f291` to see the diff.
+- Entries explain symptom + cause, not just "fixed."
+- No version tags exist (static site, no manifest); milestones are date-stamped instead.
+
+---
+
+## [Unreleased]
+_Changes on `claude/add-context-documentation-aBKjZ`, not yet merged to `main`._
+
+### Added
+- `CONTEXT.md` at repo root — single source-of-truth onboarding file for AI assistants and the author after long gaps. `(2921fec)`
+
+### Architectural
+- Documented in `CONTEXT.md` that `GEMINI.md`'s `docx.js` claim is wrong — verified zero `<script src>` tags; export is `.txt` + clipboard-to-Google-Docs only. `(2921fec)`
+
+---
+
+## 2026-04-15 — hub rewrite v2 + Traumato-ped stub
+
+### Added
+- `services/CCI-A (Traumato-ped)/` folder with placeholder `index.html` + `idea.txt` — opening slot for the next specialty template. `(97150ce, 74734ed)`
+
+### Changed
+- `index.html` rewritten as a structured hub: two main buttons, autocomplete search, specialty chips, and a collapsible "Ressources & Modules" panel listing the eight numbered observation modules and the eight clinXpert guides. `(97150ce)`
+- `README.md` link formatting cleaned up — bare URL replaced with proper markdown link to the GitHub Pages site. `(a29c688, c887afb)`
+
+---
+
+## 2026-04-13 — clinXpert guide pages
+
+### Added
+- Eight HTML guide pages under `clinXpert/` (Général, cardio-vasculaire, neurologique, Abdominal, pleuro-pulmonaire, ostéoarticulaire, gynécologique, urologique) with embedded YouTube videos and Papyrus-font styling for the section titles. `(e114704)`
+- `clinXpert-youtube-url.txt` — source list of the YouTube embeds used by the guide pages. `(46d576f)`
+
+---
+
+## 2026-03-15 — observation.html issue-fix sprint + tri-state UX
+
+### Added
+- Tri-state checkbox system (Normal / Anormal / Absent) for `examen clinique` Section 5, with confirmation dialog when switching N↔A and a dedicated reset button. Exports updated to reflect tri-state values. `(3519a7d, f309c6f, 4ec2353)`
+- TDM and IRM detail panels in the paraclinique section with fields for étage, fenêtre, injection, coupe, pondération. `(ac9c497)`
+- Comprehensive clinical guidance text added to both `observation.html` and `simplechecklist.html` (mnemonics, semiology hints inline). `(a2ad60c)`
+- `index.html` hub gained full repo-content integration — links to all observation modules, clinXpert guides, and external resources surfaced in one place. `(ff78921)`
+
+### Changed
+- Word export replaced with a "Build Page" button — generated a printable HTML page instead, since the prior Word path produced unusable `.docx`. `(d11127c)`
+
+### Fixed
+- CHU links pointed at wrong/dead hosts — corrected Fès and Oujda URLs and removed the non-existent Settat entry. `(53c03a4)`
+- ClinXpert PDF link in the floating-island menu was 404ing — repointed to the raw GitHub URL. `(f06f2e4)`
+- Batch fix for open issues #1, #4, #6, #7, #8, #9, #10 on `observation.html` (form validation, label corrections, missing fields). `(f04bd4b)`
+
+---
+
+## 2026-03-02 → 2026-03-08 — observation.html restructure + dropdown menu
+
+### Changed
+- `observation.html` heavily restructured across many small "update" commits — large symmetric insert/delete diffs (~1190 lines, ~611 lines, ~1338 lines moved) indicate section reordering and a rename of `observation_text_prises.html` → `observation_1.html`. `(da4bbff, 9864e3b, f39ad06, c4222db, 6996c47, d0441ae)`
+- Added dropdown menu in `observation.html` for navigating between observation sections. `(da4bbff)`
+
+### Added
+- Module file `observation_ressources/0_informations_clinicien.html` extracted from the monolith for modular prototyping. `(0def7b7)`
+- `observation_ressources/2. atcds/diabete.txt` — reference text for the diabetes ATCD sub-fields. `(c9ee204)`
+- Lab-reference PDFs and biological-values catalogues under `observation_ressources/7. paraclinique/bilan biologique/`. `(4e2d641, 4fc2ded)`
+- Backup snapshots `backup/observation_backup/observation - Copy.html` and `observation - before edit.html` at the root — manual restore points before risky edits. `(8e37a78, 98887fc)`
+
+### Architectural
+- `observation_ressources/GEMINI.md` introduced and refined — defined the "modular prototyping then fuse into root" workflow, no `.floating-island` in modules, UTF-8 no BOM, French only. `(b3323ad, a6f9016)`
+
+---
+
+## 2026-02-17 → 2026-02-22 — initial bring-up + hub mode
+
+### Added
+- `simplechecklist.html` — mobile-first bedside checklist with floating-island top bar, system-by-system checkboxes, progress indicator. `(247ae7c, plus earlier vague commits)`
+- Service folders `services/ccv/`, `services/hemato/`, `services/radio/` with placeholder HTML files. `(d81d99d)`
+- `clinXpert/` reference library populated with `+++ AIO`, observation source PDFs, and `Examen clinique normal.pdf`. `(0ad775c, 1af00fd, 668aec9)`
+- `other checklist/` reference: `Obs_Check_PC_STI.doc`, `Observation-packet`, `acute-transfer-checklist.pdf` and other external observation templates for inspiration. `(6c4338c, e5b4e07)`
+
+### Architectural
+- "Hub mode" — `secret.html` renamed to `observation.html`, new `index.html` introduced as the navigation hub. Old hub preserved under `backup/index latest.html`. `(520d848, d64b686, 70c4c04)`
+- Repository converted from "single big HTML file (`secret.html`)" to multi-page hub-and-spoke layout. `(520d848, 3c514e6, 2304b5c)`
+- `.gitignore` added to exclude two large copyrighted Sémiologie PDFs from `observation_ressources/`. `(e1cae60, 0ad775c)`
+
+### Broken
+- A long string of single-character "u" / "re" / "updaet" commits in this window — diffs are mostly Windows `Zone.Identifier` ADS files and binary PDF additions. Real intent for any single one is unrecoverable from the message; rely on diffs. `(18d9a68, ef0cb48, e5b4e07, d7ea9dc, 4778fe9, 330cc11, 8e37a78, etc.)`
+
+---
+
+<details>
+<summary>Archive — entries older than 12 months</summary>
+
+_(Empty. The repo's first commit is 2026-02-17, well within the 12-month window from today, 2026-04-27.)_
+
+</details>
+
+---
+
+## Update Protocol (Verbatim)
+> **For the AI Assistant:** When asked to "Update CHANGELOG.md":
+> 1. Find the most recent SHA cited in the existing file.
+> 2. Run `git log` and `git diff --stat` for everything since that SHA.
+> 3. Apply the WIP Decoder — derive intent from diffs when commit messages are vague (this repo has many one-letter "u" / "re" / "update" commits — always inspect the stat).
+> 4. Group consecutive same-intent commits into single entries; split when intent changes.
+> 5. Skip noise (lockfiles, formatter passes, typos, no-op commits, `Zone.Identifier` ADS files).
+> 6. No `package.json` exists — use natural date-stamped milestones instead of version tags.
+> 7. Append new entries above existing ones. **Never rewrite past entries** except to fix factual errors (and note the correction inline).
+> 8. Roll entries older than 12 months from today's date into the `<details>` archive.
+> 9. Keep the file under 600 lines and every entry under 2 lines.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,73 @@
+# Clinique To-Do — AI Context File
+_Last synced: 2026-04-27 @ 74734ed_
+
+## 1. What This Is (Plain English)
+- **In one sentence:** A French-language website that helps Moroccan medical students and doctors take a complete patient observation (history + physical exam) without forgetting anything, and spits out a clean text report at the end.
+- **Why it exists:** The author is a med student / junior doctor who got tired of forgetting items during bedside exams and re-typing the same boilerplate observation into Word every time. This is the personal "checklist + form-filler + report generator" that fixes that.
+- **Who uses it:** The author and friends (medical students/interns). Public-facing on GitHub Pages but not advertised. Treat as a personal tool — UX polish matters more than enterprise rigor.
+- **Vibe:** Polished personal tool. Single-file vanilla HTML/JS, no build step, no npm. Lots of medical content baked into the HTML. Written by a vibe coder using AI assistants (Claude / Gemini), so commits are large and hand-edits are rare.
+
+## 2. How To Run It
+- **Setup once:** Nothing. No `npm install`, no Python venv, no Docker. It's static HTML.
+- **Run dev:** Open `index.html` in a browser. That's it. For nicer paths during dev: `python3 -m http.server` from the repo root, then visit `http://localhost:8000/`.
+- **Build / deploy:** No build. Deployed via **GitHub Pages** from the `main` branch — pushing to `main` updates `https://achma-learning.github.io/clinique_to_do/` (per `README.md:1`). No `.github/workflows/` exists yet.
+- **Required env vars:** None. No `.env.example`, no secrets, no backend.
+
+## 3. Tech Stack
+- **Language + runtime:** Plain HTML5 + CSS + vanilla JavaScript (ES6+, runs straight in modern browsers). No transpiler, no module bundler.
+- **Framework / key libraries:** **None.** Zero `<script src>` tags across `index.html`, `simplechecklist.html`, `observation.html` (verified). All logic is inline. No `package.json`, no lockfile.
+  - ⚠️ `GEMINI.md:14` claims `docx.js` is used for `.docx` export — **this is wrong**. The actual export buttons are `.txt` download (`observation.html:2358`) and "Google Docs" via `navigator.clipboard.writeText` + opening `docs.new` (`observation.html:3361`). No real `.docx` generation exists.
+- **What kind of project:** Static multi-page web app, deployed on GitHub Pages. Effectively three single-file apps that link to each other.
+- **External services:** None at runtime. Outbound links only — `clinxpert.glide.page` (a separate Glide app), Moroccan health sites (MSPS, AMMPS, the 6 CHUs), and `docs.new` for the Google Docs paste flow.
+
+## 4. Code Map (The Important Files Only)
+- `index.html` — The hub. Two main buttons (Checklist / Observation), specialty search with autocomplete (`index.html:518` defines the `specialties` array), chips for direct specialty links, and a collapsible panel of resources + module links + clinXpert guides. Self-contained, ~530 lines.
+- `simplechecklist.html` — Mobile-first bedside checklist. Floating-island top bar, progress tracking, system-by-system checkboxes (~590 lines). Use this on a phone at the patient's bedside.
+- `observation.html` — The big one (~3430 lines). Desktop form that captures the full medical observation (identité, ATCDs, histoire de la maladie, examen clinique, paraclinique with biological reference-range validation, conclusion, CAT). Generates a printable page (`generatePage`), `.txt` download (`generateTxt`), or copies to clipboard for pasting into Google Docs (`generateGoogleDocs`).
+- `observation_ressources/` — Modular staging area. Each `0_..` to `6_..` HTML file is a standalone section being prototyped before being "fused" into `observation.html`. See `observation_ressources/GEMINI.md` for the fusion rules (no floating-island in modules, keep `name`/`id` identical to root, UTF-8 no BOM, French only).
+- `services/<spe>/<spe>.html` — Specialty-specific templates. Currently `ccv/` (cardio-vasc), `hemato/`, `radio/`, plus a stub `CCI-A (Traumato-ped)/`. Each is a standalone copy of the observation form tailored for that service.
+- `clinXpert/` — Reference library. HTML + matching `.txt` per body system (Général, cardio-vasculaire, Abdominal, neurologique, pleuro-pulmonaire, ostéoarticulaire, gynécologique, urologique). Linked from the hub's "Guides clinXpert" section. The `.txt` files are the source-of-truth medical content; the `.html` files are the styled presentation.
+- `backup/` — Old versions kept around on purpose (see §6).
+- `other/idea.txt`, `other/plan.txt`, `other/note to update.txt` — The author's running roadmap notes.
+- `GEMINI.md` — Older AI context file. Mostly accurate on structure; **wrong about `docx.js`** (see §3).
+- `README.md` — Tiny human-facing pointer to the live site.
+
+## 5. Rules For Editing This Code
+- **Zero dependencies, on purpose.** Do **not** add `npm`, a bundler, a framework, or any `<script src="https://cdn...">` tag. If you need a library, paste it inline or argue for it first.
+- **Static-site only.** No backend. No build step. Anything you ship must work by double-clicking the HTML file or serving it from GitHub Pages.
+- **French is the product language.** All labels, placeholders, toasts, comments-visible-to-user must stay in French. Code identifiers can be French or English (existing code mixes both).
+- **UTF-8 without BOM.** Preserve French accents as literal characters (`é`, `è`, `à`, `ç`). Do not convert to HTML entities (`&eacute;`). Per `observation_ressources/GEMINI.md:22`.
+- **Modular files in `observation_ressources/` follow extra rules** (per `observation_ressources/GEMINI.md`):
+  - No `.floating-island` header — they're meant to be viewed as partials.
+  - Use `padding-top: 20px` on `body` (not `80px` like the root).
+  - Keep `id`/`name` attributes identical to `observation.html` so the fusion merge keeps export logic working.
+- **Mobile matters.** `simplechecklist.html` is used on phones at the bedside. Don't break the responsive layout or the floating-island header.
+- **Don't rename anchors / IDs in `observation.html` casually.** The export functions (`buildObservationText`, `generateTxt`, `generateGoogleDocs`) walk the form by `name=` — renaming silently breaks the report output.
+
+## 6. Fragile Bits & Landmines
+- **Filenames with spaces, accents, parentheses are intentional and load-bearing.** Examples: `clinXpert/Général.html`, `clinXpert/ostéoarticulaire.html`, `clinXpert/+++ these interne - observation médicale.docx`, `services/CCI-A (Traumato-ped)/`, `observation_ressources/0. information clinicien/`, `observation - before edit.html`. The `index.html` and `observation.html` link to these exact strings — renaming any of them breaks links silently. Check `index.html:402-425` before "tidying" the `clinXpert/` folder.
+- **`backup/` is not auto-deletable.** It contains `index latest.html`, `index old.html`, `v1.html`, `v1.2.html`, `v2.html`, `checklist for mobile.html`, plus `simplechecklist_backup/` and `observation_backup/`. These are the author's manual restore points after a vibe-coding session goes sideways. Do not delete on a "cleanup" pass.
+- **`observation - before edit.html` (~178 KB) and `observation_old_but_working caractere.txt` (~158 KB) at the repo root** look like junk but are kept as reference snapshots when accents broke. Leave them.
+- **`.gitignore` only excludes two specific PDFs** (in `observation_ressources/1. Sémiologie/` and `organise this/1. Sémiologie/`) — likely copyrighted textbooks the author doesn't want on GitHub. Don't `git add -f` them.
+- **`generateGoogleDocs` (`observation.html:3361`) auto-opens `docs.new` in a new tab** ~800ms after the clipboard write. Browsers may block this as a popup if the user didn't trigger via a real click — keep the call inside the click handler chain.
+- **`navigator.clipboard.writeText` falls back to a hidden `<textarea>` + `document.execCommand('copy')`** (`observation.html:3367-3372`). The `execCommand` path is deprecated but still works in current browsers; don't rip it out without testing on Safari iOS where the Clipboard API is finicky.
+- **The "search bar" in `index.html` uses an inline-defined `autocomplete()` function** (`index.html:444`) and a hardcoded `specialties` array (`index.html:518`). If you add a new service folder, you must also add it to that array, or it won't show up in the search.
+- **`services/hemato/ccv.htmlZone.Identifier`** is a Windows ADS leftover from a download — harmless but ugly. Safe to delete; not load-bearing.
+- **The `clinXpert` ↔ `clinxpert` casing mismatch** is real. The folder is `clinXpert/` (capital X). Linux deployments (GitHub Pages) are case-sensitive, so any link must match exactly.
+
+## 7. Current State
+- **Last shipped:** `idea.txt` added under `services/CCI-A (Traumato-ped)/` (commit `74734ed`); `index.html` rewritten with the new hub layout (chips + collapsible Resources & Modules panel + ClinXpert guides) and Papyrus-styled clinXpert section (commits `97150ce`, `898e7f3`).
+- **Working on now:** Adding/refreshing AI context documentation on branch `claude/add-context-documentation-aBKjZ` (this file).
+- **Next up** (from `other/idea.txt`, `other/plan.txt`, `other/note to update.txt`):
+  1. Build out more service templates under `services/` (start with what `observation.html` already covers, scrub patient names from any sample `ressources/`).
+  2. When an ATCD checkbox like HTA / Diabète is ticked, reveal sub-fields for treatment, posologie, nb de prises (per `other/note to update.txt`).
+  3. Make `.docx` export actually work — current "Word" path is just clipboard-to-Google-Docs.
+
+## 8. Update Protocol (Verbatim)
+> **For the AI Assistant:** When asked to "Update CONTEXT.md":
+> 1. Re-run Phase 0 — check for new `GEMINI.md` / `CLAUDE.md` / `.github/` files.
+> 2. Re-scan the tree, manifests, and `.github/workflows/` for drift.
+> 3. Read our recent conversation for new decisions, fragile bits discovered, or shifted goals.
+> 4. Refresh the `_Last synced_` line with today's date and current commit SHA.
+> 5. Rewrite — do not append. One clean source of truth. Preserve still-true content, revise the rest.
+> 6. Keep §1 and §2 in plain English. Keep the file under ~350 lines.


### PR DESCRIPTION
## Summary
- Adds `CONTEXT.md` at the repo root as the single source-of-truth context file for future AI assistants (and the author after a 3-month gap).
- Plain-English overview of what the project is and how to run it (no build, just open `index.html` or `python3 -m http.server`).
- Code map of the three load-bearing files (`index.html`, `simplechecklist.html`, `observation.html`) plus `observation_ressources/`, `services/`, `clinXpert/`, `backup/`.
- Editing rules: zero dependencies on purpose, French-only product language, UTF-8 without BOM, modular-file conventions from `observation_ressources/GEMINI.md`.
- Fragile-bits list: accented/spaced filenames are load-bearing, `backup/` is intentional restore points, clipboard fallback in `generateGoogleDocs`, `clinXpert` casing on case-sensitive GitHub Pages.

## Notable correction vs. existing docs
- `GEMINI.md` claims `docx.js` is used for `.docx` export. Verified there are zero `<script src>` tags in any HTML file — the actual export is `.txt` download + `navigator.clipboard.writeText` to paste into Google Docs (`observation.html:3361`). `CONTEXT.md` flags this so the next AI doesn't chase a phantom dependency.

## Test plan
- [ ] `CONTEXT.md` renders cleanly on GitHub
- [ ] All cited file paths and line numbers (`index.html:518`, `observation.html:3361`, etc.) still resolve
- [ ] File length stays under the 350-line cap

https://claude.ai/code/session_01HtbFRsWBM8WX2JaTRZc1Lf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtbFRsWBM8WX2JaTRZc1Lf)_